### PR TITLE
FC-356 fix: correct sorted created by

### DIFF
--- a/src/common/globalVariables.ts
+++ b/src/common/globalVariables.ts
@@ -2,7 +2,7 @@ export const headersNameDecks = [
   { key: 'name', locale: 'tableComponentWithTypes.name', title: 'Name' },
   { key: 'cardsCount', locale: 'tableComponentWithTypes.cards', title: 'Cards' },
   { key: 'updated', locale: 'tableComponentWithTypes.lastUpdated', title: 'Last Updated' },
-  { key: 'created', locale: 'tableComponentWithTypes.createdBy', title: 'Created by' },
+  { key: 'author.name', locale: 'tableComponentWithTypes.createdBy', title: 'Created by' },
 ]
 
 export const headersNameCards = [

--- a/src/components/TableComponent/TableComponentWithTypes.tsx
+++ b/src/components/TableComponent/TableComponentWithTypes.tsx
@@ -93,7 +93,7 @@ export const TableComponentWithTypes = memo(
                     <Typography as={'button'} className={s.nameSortBtn} variant={'subtitle2'}>
                       {/*{name.title}*/}
                       {t(`${name.locale}`)}
-                      {currentOrderBy.includes(name.key) && (
+                      {(currentOrderBy === `${name.key}-asc` || currentOrderBy === `${name.key}-desc`)  && (
                         <ArrowIosDownOutline
                           className={`${s.arrow} ${currentOrderBy.includes('asc') ? s.rotate : ''}`}
                         />


### PR DESCRIPTION
В TableComponentWithTypes сделал более строгую проверку по name.key (логика стрелки ArrowIosDownOutline)
Из-за 'name' и 'author.name'

В headersNameDecks заменил key 'created' на 'author.name'